### PR TITLE
Update Https_Handler.cpp

### DIFF
--- a/ProviderExample/src/Interface/Https_Handler.cpp
+++ b/ProviderExample/src/Interface/Https_Handler.cpp
@@ -288,6 +288,10 @@ extern "C" int MHD_Callback_Https(void *cls,
         ret = MHD_queue_response(connection, MHD_HTTP_OK, response);
         MHD_destroy_response(response);
      }
+ 
+     // free dynamically allocated memory
+     free (clientDistinguishedName);
+     gnutls_x509_crt_deinit(client_cert);
 
      return ret;
 }


### PR DESCRIPTION
Fix of the memory leak in function MHD_Callback_Https.
One hidden malloc in function get_client_cert called on line 268.
Another hidden malloc in function get_auth_dn called on line 273.